### PR TITLE
upgrade cloudant-client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     }
 
     // Cloudant
-    compile group: 'com.cloudant', name: 'cloudant-client', version:'1.0.1'
+    compile group: 'com.cloudant', name: 'cloudant-client', version:'1.2.3'
 
     // Spring Cloud
     compile(group: 'org.springframework.cloud', name: 'spring-cloud-config-client', version:'1.0.1.RELEASE') {

--- a/src/main/java/org/springframework/data/cloudant/core/CloudantTemplate.java
+++ b/src/main/java/org/springframework/data/cloudant/core/CloudantTemplate.java
@@ -51,13 +51,24 @@ public class CloudantTemplate<T extends BaseDocument> implements CloudantOperati
     private Database database;
     private final Logger logger = LoggerFactory.getLogger(CloudantTemplate.class);
 
+    // the constructor using false as default in create parameter
+    public CloudantTemplate(final ICloudantConnector dbConnector){
+        this.client = dbConnector.getClient();
+        this.database = this.client.database(dbConnector.getDbName(), false);
+    }
+
+    // the constructor using false as default in create parameter
+    public CloudantTemplate(final CloudantClient client, final String databaseName) {
+        this.client = client;
+        this.database = this.client.database(databaseName, false);
+    }
+
     public CloudantTemplate(final ICloudantConnector dbConnector, Boolean create){
         this.client = dbConnector.getClient();
         this.database = this.client.database(dbConnector.getDbName(), create);
     }
     public CloudantTemplate(final CloudantClient client, final String databaseName, Boolean create) {
         this.client = client;
-
         this.database = this.client.database(databaseName, create);
     }
 

--- a/src/main/java/org/springframework/data/cloudant/core/CloudantTemplate.java
+++ b/src/main/java/org/springframework/data/cloudant/core/CloudantTemplate.java
@@ -19,24 +19,26 @@
 
 package org.springframework.data.cloudant.core;
 
-import com.cloudant.client.api.Database;
 import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
 import com.cloudant.client.api.model.*;
-
-import com.cloudant.client.api.model.SearchResult;
 import com.google.gson.GsonBuilder;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.data.cloudant.config.ICloudantConnector;
-import org.springframework.data.cloudant.core.mapping.event.*;
+import org.springframework.data.cloudant.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.cloudant.core.mapping.event.BeforeSaveEvent;
+import org.springframework.data.cloudant.core.mapping.event.CloudantMappingEvent;
 import org.springframework.data.cloudant.core.model.BaseDocument;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 
-import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by justinsaul on 6/9/15.
@@ -49,14 +51,14 @@ public class CloudantTemplate<T extends BaseDocument> implements CloudantOperati
     private Database database;
     private final Logger logger = LoggerFactory.getLogger(CloudantTemplate.class);
 
-    public CloudantTemplate(final ICloudantConnector dbConnector){
+    public CloudantTemplate(final ICloudantConnector dbConnector, Boolean create){
         this.client = dbConnector.getClient();
-        this.database = this.client.database(dbConnector.getDbName(), true);
+        this.database = this.client.database(dbConnector.getDbName(), create);
     }
-    public CloudantTemplate(final CloudantClient client, final String databaseName) {
+    public CloudantTemplate(final CloudantClient client, final String databaseName, Boolean create) {
         this.client = client;
 
-        this.database = this.client.database(databaseName, true);
+        this.database = this.client.database(databaseName, create);
     }
 
     @Override


### PR DESCRIPTION
- upgrade to 1.2.3 in cloudant-client
- add two constructor which make default parameter in create

following changes after upgrade cloudant-client, old version is 1.0.1, the cloudant team turned out issue with HTTP, so we need upgrade over 1.2.1, because bigger changes in 2.0.0, so keep it on 1.2.3
